### PR TITLE
Add a "Room unavailable" screen

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,3 +51,8 @@ jekyll_get_json:
 collections:
   phases:
     output: true
+
+# For the TV display, when to turn the screen on/off
+tv:
+  on_time: "08:00"
+  off_time: "18:00"

--- a/_layouts/tv.html
+++ b/_layouts/tv.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title }} &bull; Envoy Ready to Reopen</title>
+    <link rel="stylesheet" href="/assets/css/fonts.css">
+    <link rel="stylesheet" href="/assets/css/site.css">
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="/assets/scripts/site.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js" integrity="sha512-rmZcZsyhe0/MAjquhTgiUcb4d9knaFc7b5xAfju483gbEXTkeJRUMIPk6s3ySZMYUHEcjKbjLjyddGWMrNEvZg==" crossorigin="anonymous"></script>
+  </head>
+  <body class="text-arctic bg-black h-screen">
+    <div id="wrapper" class="w-full flex justify-center items-center h-full">
+      {{ content }}
+    </div>
+
+    <script>
+    $(function() {
+      setInterval(function() {
+        var time_check = moment().isBetween(moment('{{ site.tv.on_time }}', 'hh:mm'), moment('{{ site.tv.off_time }}', 'hh:mm'))
+        console.log(time_check)
+        $('#wrapper').toggleClass('hidden', !time_check)
+      },
+      10*1000); // Run this every 10 seconds
+    })
+    </script>
+  </body>
+</html>

--- a/pages/room-unavailable.html
+++ b/pages/room-unavailable.html
@@ -1,0 +1,19 @@
+---
+layout: tv
+title: Room unavailable
+---
+
+<div class="text-center w-2/3">
+  <h1 class="text-6xl text-carbon10 mb-4" style="font-size: 8rem;">&#x26D4;</h1>
+  <h1 class="text-6xl text-arctic mb-8 font-semibold">Room unavailable</h1>
+
+  <p class="text-2xl text-carbon40">
+    In our current reopening phase, this room isn't available.
+    <br />
+    Thank you for your understanding.
+  </p>
+
+  <p class="text-xl text-carbon80 mt-12">
+    #BackToWorkSafely
+  </p>
+</div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,7 @@ module.exports = {
         powder: '#B5DFEB',
         cilantro: '#21944E',
         pistachio: '#D3D236',
+        black: '#000'
       },
       lineHeight: {
         'extra-tight': '0.8'


### PR DESCRIPTION
This can be used to replace Zoom Room TV displays, room scheduler displays, etc. 

Turns off the display at 6pm local time and turns it back on at 8 am.